### PR TITLE
Add test tsom sparse

### DIFF
--- a/libs/models/tsom_sparse.py
+++ b/libs/models/tsom_sparse.py
@@ -131,8 +131,8 @@ class TSOM2():
             self.m_step_indirect(epoch)
 
     def e_step_indirect(self):
-        self.k_star1 = np.argmin(np.sum(np.square(self.u[:, None, :, :] - self.y[None, :, :, :]), axis=(2, 3)), axis=1)
-        self.k_star2 = np.argmin(np.sum(np.square(self.v[:, :, None, :] - self.y[:, None, :, :]), axis=(0, 3)), axis=1)
+        self.k_star1 = np.argmin(np.sum(np.square(self.u[:, None, :] - self.y[None, :, :]), axis=2), axis=1)
+        self.k_star2 = np.argmin(np.sum(np.square(self.v[:, :, None] - self.y[:, None, :]), axis=0), axis=1)
         self.z1 = self.zeta1[self.k_star1, :]
         self.z2 = self.zeta2[self.k_star2, :]
 

--- a/libs/models/tsom_sparse.py
+++ b/libs/models/tsom_sparse.py
@@ -105,14 +105,12 @@ class TSOM2():
         self.history['z1'] = np.zeros((nb_epoch, self.n_samples1, self.latent_dim1))
         self.history['z2'] = np.zeros((nb_epoch, self.n_samples2, self.latent_dim2))
 
-        self.m_step(0, is_direct)
-
     def fit(self, nb_epoch=200, is_direct=True):
         self.initialization(nb_epoch, is_direct)
 
         for epoch in tqdm(np.arange(nb_epoch)):
-            self.e_step(is_direct)
             self.m_step(epoch, is_direct)
+            self.e_step(is_direct)
 
             self.history['y'][epoch, :, :] = self.y
             self.history['z1'][epoch, :] = self.z1

--- a/libs/tools/calc_sigma.py
+++ b/libs/tools/calc_sigma.py
@@ -1,0 +1,43 @@
+import numpy as np
+from enum import Enum, auto
+
+
+class SigmaMode(Enum):
+    LINEAR = auto()
+    EXPONENTIAL = auto()
+
+
+def calc_sigma(mode: SigmaMode, sigma_max: float, sigma_min: float, tau: float, epoch: int) -> float:
+    if mode is SigmaMode.LINEAR:
+        return __calc_sigma_linear(sigma_max, sigma_min, tau, epoch)
+    elif mode is SigmaMode.EXPONENTIAL:
+        return __calc_sigma_exp(sigma_max, sigma_min, tau, epoch)
+    else:
+        raise NotImplementedError()
+
+
+def __calc_sigma_exp(sigma_max: float, sigma_min: float, tau: float, epoch: int) -> float:
+    return sigma_min + (sigma_max - sigma_min) * np.exp(-epoch / tau)
+
+
+def __calc_sigma_linear(sigma_max: float, sigma_min: float, tau: float, epoch: int) -> float:
+    return max(sigma_min, sigma_max * (1 - (epoch / tau)))
+
+
+if __name__ == '__main__':
+    import matplotlib.pyplot as plt
+    fig, ax = plt.subplots()
+
+    sigma_max = 1.0
+    sigma_min = 0.1
+    tau = 10.0
+    max_epoch = 100
+
+    x = np.arange(max_epoch)
+
+    for sigma_mode in SigmaMode:
+        y = [calc_sigma(sigma_mode, sigma_max, sigma_min, tau, epoch) for epoch in x]
+        ax.plot(x, y, label=sigma_mode.name)
+
+    ax.legend()
+    plt.show()

--- a/tests/tsom/allclose_dense_vs_sparse.py
+++ b/tests/tsom/allclose_dense_vs_sparse.py
@@ -1,0 +1,56 @@
+import unittest
+
+import numpy as np
+from scipy import sparse
+
+from libs.models.tsom import TSOM2 as TSOM2Dense
+from libs.models.tsom_sparse import TSOM2 as TSOM2Sparse
+
+
+class TestTSOM2(unittest.TestCase):
+    def test_dense_vs_sparse(self):
+        # random seed setting
+        seed = 100
+        np.random.seed(seed)
+
+        # prepare observed data
+        nb_samples1 = 10
+        nb_samples2 = 20
+        # observed_dim = 1
+
+        X = np.random.randint(0, 3, (nb_samples1, nb_samples2))
+        X_sparse = sparse.csr_matrix(sparse.lil_matrix(X))
+
+        # set learning parameter
+        nb_epoch = 60
+        latent_dim = [1, 2]
+        resolution = [7, 9]
+        sigma_max = [2.0, 2.2]
+        sigma_min = [0.4, 0.2]
+        tau = [50, 60]
+
+        # prepare init
+        Z1init = np.random.rand(nb_samples1, latent_dim[0])
+        Z2init = np.random.rand(nb_samples2, latent_dim[1])
+        init = [Z1init, Z2init]
+
+        # generate tsom instance
+        tsom_dense = TSOM2Dense(X, latent_dim=latent_dim, resolution=resolution,
+                                SIGMA_MAX=sigma_max, SIGMA_MIN=sigma_min, TAU=tau,
+                                init=init)
+        tsom_sparse = TSOM2Sparse(X_sparse, latent_dim=latent_dim, resolution=resolution,
+                                  sigma_max=sigma_max, sigma_min=sigma_min, tau=tau,
+                                  init=init, sigma_mode="LINEAR")
+
+        # learn
+        tsom_dense.fit(nb_epoch=nb_epoch)
+        tsom_sparse.fit(nb_epoch=nb_epoch, is_direct=False)
+
+        # test
+        np.testing.assert_allclose(tsom_dense.history['y'][:, :, :, 0], tsom_sparse.history['y'])
+        np.testing.assert_allclose(tsom_dense.history['z1'], tsom_sparse.history['z1'])
+        np.testing.assert_allclose(tsom_dense.history['z2'], tsom_sparse.history['z2'])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
** Description 説明 **
`tsom_sparse.py` と `tsom.py` の学習結果が一致するか確認するテストコード`allclose_dense_vs_sparse.py` を追加しました．

また学習の設定を合わせるために，`tsom_sparse.py`に関して以下のように修正しました．
- 近傍半径のスケジューリングに用いる関数を簡単に指定できるよう，`calc_sigma.py`を作成
- `tsom_sparse.py`の近傍半径のスケジューリングに用いる関数を宣言時に指定できるよう変更
- `tsom_sparse.py`の学習順序を`tsom.py`に合わせる（e-step, m-step -> m-step, e-step）
- メンバ変数の`shape`関連のバグ修正
