### PR TITLE
SOM2の使用を見越してSOMを改良しました

### DIFF
--- a/libs/models/som.py
+++ b/libs/models/som.py
@@ -6,7 +6,7 @@ from sklearn.decomposition import PCA
 
 
 class SOM:
-    def __init__(self, X, latent_dim, resolution, sigma_max, sigma_min, tau, init='random',metric="sqeuclidean"):
+    def __init__(self, X, latent_dim, resolution, sigma_max, sigma_min, tau, init='random', metric="sqeuclidean"):
         self.X = X
         self.N = self.X.shape[0]
 
@@ -16,6 +16,8 @@ class SOM:
 
         self.D = X.shape[1]
         self.L = latent_dim
+
+        self.UpdateFromY = True
 
         self.history = {}
 
@@ -39,6 +41,9 @@ class SOM:
 
         if isinstance(init, str) and init == 'random':
             self.Z = np.random.rand(self.N, latent_dim) * 2.0 - 1.0
+        elif isinstance(init, str) and init == 'random_y':
+            self.Y = np.random.rand(self.K, self.D) * 2.0 - 1.0
+            self.UpdateFromY = False
         elif isinstance(init, str) and init == 'random_bmu':
             init_bmus = np.random.randint(0, self.Zeta.shape[0] - 1, self.N)
             self.Z = self.Zeta[init_bmus,:]
@@ -107,12 +112,14 @@ class SOM:
             bar = range(nb_epoch)
 
         for epoch in bar:
-            # 協調過程
-            self._cooperative_process(epoch)
-            # 適合過程
-            self._adaptive_process()
-            # 競合過程
-            self._competitive_process()
+            if self.UpdateFromY:
+                self._cooperative_process(epoch)   # 協調過程
+                self._adaptive_process()           # 適合過程
+                self._competitive_process()        # 競合過程
+            else:
+                self._competitive_process()        # 競合過程
+                self._cooperative_process(epoch)   # 協調過程
+                self._adaptive_process()           # 適合過程
 
             self.history['z'][epoch] = self.Z
             self.history['y'][epoch] = self.Y

--- a/libs/models/som.py
+++ b/libs/models/som.py
@@ -17,8 +17,6 @@ class SOM:
         self.D = X.shape[1]
         self.L = latent_dim
 
-        self.UpdateFromY = True
-
         self.history = {}
 
         if isinstance(init, str) and init == 'PCA':
@@ -41,9 +39,6 @@ class SOM:
 
         if isinstance(init, str) and init == 'random':
             self.Z = np.random.rand(self.N, latent_dim) * 2.0 - 1.0
-        elif isinstance(init, str) and init == 'random_y':
-            self.Y = np.random.rand(self.K, self.D) * 2.0 - 1.0
-            self.UpdateFromY = False
         elif isinstance(init, str) and init == 'random_bmu':
             init_bmus = np.random.randint(0, self.Zeta.shape[0] - 1, self.N)
             self.Z = self.Zeta[init_bmus,:]
@@ -115,14 +110,9 @@ class SOM:
             bar = range(nb_epoch)
 
         for epoch in bar:
-            if self.UpdateFromY:
-                self._cooperative_process(epoch)   # 協調過程
-                self._adaptive_process()           # 適合過程
-                self._competitive_process()        # 競合過程
-            else:
-                self._competitive_process()        # 競合過程
-                self._cooperative_process(epoch)   # 協調過程
-                self._adaptive_process()           # 適合過程
+            self._cooperative_process(epoch)   # 協調過程
+            self._adaptive_process()           # 適合過程
+            self._competitive_process()        # 競合過程
 
             self.history['z'][epoch] = self.Z
             self.history['y'][epoch] = self.Y

--- a/libs/models/som.py
+++ b/libs/models/som.py
@@ -100,6 +100,9 @@ class SOM:
             # argmin(axis=1)を用いて各行で最小値を探しそのインデックスを返す
             self.Z = self.Zeta[bmus, :]  # 勝者ノード番号から勝者ノードを求める
 
+    def update_mapping(self, Y):
+        self.Y = Y
+
     def fit(self, nb_epoch=100, verbose=True):
 
         self.history['z'] = np.zeros((nb_epoch, self.N, self.L))

--- a/libs/models/som.py
+++ b/libs/models/som.py
@@ -88,17 +88,17 @@ class SOM:
         if self.metric is "sqeuclidean":  # ユークリッド距離を使った勝者決定
             # 勝者ノードの計算H
             Dist = dist.cdist(self.X, self.Y)  # NxKの距離行列を計算
-            bmus = Dist.argmin(axis=1)
+            self.bmus = Dist.argmin(axis=1)
             # Nx1の勝者ノード番号をまとめた列ベクトルを計算
             # argmin(axis=1)を用いて各行で最小値を探しそのインデックスを返す
-            self.Z = self.Zeta[bmus, :]  # 勝者ノード番号から勝者ノードを求める
+            self.Z = self.Zeta[self.bmus, :]  # 勝者ノード番号から勝者ノードを求める
         elif self.metric is "KLdivergence":  # KL情報量を使った勝者決定
             Dist = np.sum(self.X[:, np.newaxis, :] * np.log(self.Y)[np.newaxis, :, :], axis=2)  # N*K行列
             # 勝者番号の決定
-            bmus = np.argmax(Dist, axis=1)
+            self.bmus = np.argmax(Dist, axis=1)
             # Nx1の勝者ノード番号をまとめた列ベクトルを計算
             # argmin(axis=1)を用いて各行で最小値を探しそのインデックスを返す
-            self.Z = self.Zeta[bmus, :]  # 勝者ノード番号から勝者ノードを求める
+            self.Z = self.Zeta[self.bmus, :]  # 勝者ノード番号から勝者ノードを求める
 
     def update_mapping(self, Y):
         self.Y = Y

--- a/libs/models/som.py
+++ b/libs/models/som.py
@@ -63,6 +63,38 @@ class SOM:
 
         self.history = {}
 
+    def _cooperative_process(self, epoch):
+        # 学習量を計算
+        # sigma = self.sigma_min + (self.sigma_max - self.sigma_min) * np.exp(-epoch / self.tau) # 近傍半径を設定
+        self.sigma = max(self.sigma_min, self.sigma_max * (1 - (epoch / self.tau)))  # 近傍半径を設定
+        Dist = dist.cdist(self.Zeta, self.Z, 'sqeuclidean')
+        # KxNの距離行列を計算
+        # ノードと勝者ノードの全ての組み合わせにおける距離を網羅した行列
+        self.H = np.exp(-Dist / (2 * self.sigma * self.sigma))  # KxNの学習量行列を計算
+
+    def _adaptive_process(self):
+        # 参照ベクトルの更新
+        G = np.sum(self.H, axis=1)[:, np.newaxis]  # 各ノードが受ける学習量の総和を保持するKx1の列ベクトルを計算
+        Ginv = np.reciprocal(G)  # Gのそれぞれの要素の逆数を取る
+        R = self.H * Ginv  # 学習量の総和が1になるように規格化
+        self.Y = R @ self.X  # 学習量を重みとして観測データの平均を取り参照ベクトルとする
+
+    def _competitive_process(self):
+        if self.metric is "sqeuclidean":  # ユークリッド距離を使った勝者決定
+            # 勝者ノードの計算H
+            Dist = dist.cdist(self.X, self.Y)  # NxKの距離行列を計算
+            bmus = Dist.argmin(axis=1)
+            # Nx1の勝者ノード番号をまとめた列ベクトルを計算
+            # argmin(axis=1)を用いて各行で最小値を探しそのインデックスを返す
+            self.Z = self.Zeta[bmus, :]  # 勝者ノード番号から勝者ノードを求める
+        elif self.metric is "KLdivergence":  # KL情報量を使った勝者決定
+            Dist = np.sum(self.X[:, np.newaxis, :] * np.log(self.Y)[np.newaxis, :, :], axis=2)  # N*K行列
+            # 勝者番号の決定
+            bmus = np.argmax(Dist, axis=1)
+            # Nx1の勝者ノード番号をまとめた列ベクトルを計算
+            # argmin(axis=1)を用いて各行で最小値を探しそのインデックスを返す
+            self.Z = self.Zeta[bmus, :]  # 勝者ノード番号から勝者ノードを求める
+
     def fit(self, nb_epoch=100, verbose=True):
 
         self.history['z'] = np.zeros((nb_epoch, self.N, self.L))
@@ -76,37 +108,12 @@ class SOM:
 
         for epoch in bar:
             # 協調過程
-            # 学習量を計算
-            # sigma = self.sigma_min + (self.sigma_max - self.sigma_min) * np.exp(-epoch / self.tau) # 近傍半径を設定
-            sigma = max(self.sigma_min, self.sigma_max * ( 1 - (epoch / self.tau) ) )# 近傍半径を設定
-            Dist = dist.cdist(self.Zeta, self.Z, 'sqeuclidean')
-            # KxNの距離行列を計算
-            # ノードと勝者ノードの全ての組み合わせにおける距離を網羅した行列
-            H = np.exp(-Dist / (2 * sigma * sigma)) # KxNの学習量行列を計算
-
+            self._cooperative_process(epoch)
             # 適合過程
-            # 参照ベクトルの更新
-            G = np.sum(H, axis=1)[:, np.newaxis] # 各ノードが受ける学習量の総和を保持するKx1の列ベクトルを計算
-            Ginv = np.reciprocal(G) # Gのそれぞれの要素の逆数を取る
-            R = H * Ginv # 学習量の総和が1になるように規格化
-            self.Y = R @ self.X # 学習量を重みとして観測データの平均を取り参照ベクトルとする
-
+            self._adaptive_process()
             # 競合過程
-            if self.metric is "sqeuclidean":  # ユークリッド距離を使った勝者決定
-                # 勝者ノードの計算
-                Dist = dist.cdist(self.X, self.Y)  # NxKの距離行列を計算
-                bmus = Dist.argmin(axis=1)
-                # Nx1の勝者ノード番号をまとめた列ベクトルを計算
-                # argmin(axis=1)を用いて各行で最小値を探しそのインデックスを返す
-                self.Z = self.Zeta[bmus, :]  # 勝者ノード番号から勝者ノードを求める
-            elif self.metric is "KLdivergence":  # KL情報量を使った勝者決定
-                Dist = np.sum(self.X[:, np.newaxis, :] * np.log(self.Y)[np.newaxis, :, :], axis=2)  # N*K行列
-                # 勝者番号の決定
-                bmus = np.argmax(Dist, axis=1)
-                # Nx1の勝者ノード番号をまとめた列ベクトルを計算
-                # argmin(axis=1)を用いて各行で最小値を探しそのインデックスを返す
-                self.Z = self.Zeta[bmus, :]  # 勝者ノード番号から勝者ノードを求める
+            self._competitive_process()
 
             self.history['z'][epoch] = self.Z
             self.history['y'][epoch] = self.Y
-            self.history['sigma'][epoch] = sigma
+            self.history['sigma'][epoch] = self.sigma

--- a/tutorials/ukr/fitting_saddle_shape.py
+++ b/tutorials/ukr/fitting_saddle_shape.py
@@ -33,7 +33,7 @@ if __name__ == '__main__':
 
     # learn ukr and som
     som = SOM(X, latent_dim=n_components, resolution=resolution,
-              sigma_max=init_bandwidth, sigma_min=bandwidth_gaussian_kernel, tau=tau)
+              sigma_max=init_bandwidth, sigma_min=bandwidth_gaussian_kernel, tau=tau, init='random_y')
     ukr = UKR(X, n_components=n_components, bandwidth_gaussian_kernel=bandwidth_gaussian_kernel,
               is_compact=is_compact, is_save_history=is_save_history, lambda_=lambda_)
     som.fit(nb_epoch=nb_epoch)

--- a/tutorials/ukr/fitting_saddle_shape.py
+++ b/tutorials/ukr/fitting_saddle_shape.py
@@ -33,7 +33,7 @@ if __name__ == '__main__':
 
     # learn ukr and som
     som = SOM(X, latent_dim=n_components, resolution=resolution,
-              sigma_max=init_bandwidth, sigma_min=bandwidth_gaussian_kernel, tau=tau, init='random_y')
+              sigma_max=init_bandwidth, sigma_min=bandwidth_gaussian_kernel, tau=tau, init='random')
     ukr = UKR(X, n_components=n_components, bandwidth_gaussian_kernel=bandwidth_gaussian_kernel,
               is_compact=is_compact, is_save_history=is_save_history, lambda_=lambda_)
     som.fit(nb_epoch=nb_epoch)


### PR DESCRIPTION
close #59 
### 概要
somfのSOMを組み合わせてSOM2を作れるように，SOMの機能は変えずに内部の処理を書き換えました．

### したこと
- somfのSOMは潜在変数zを初期化して，fit内部で写像yの更新→潜在変数zの更新のようになっていました．しかしSOM2の場合は，コピーバックの部分で初めにyを初期化する必要があったので現状とは真逆の処理に変更する必要がありました．
- そこで，SOMの「random」引数に"random_y"の条件文を追加してy初期化できるようにし，"random_y"を選択したときはfit内部で潜在変数zの更新→写像yの更新となるように変更しました．
- そのように内容を変更するにあたって，fit内部の競合過程，適合過程，協調過程の部分を関数化しました．
- 1epochごとにyを更新（コピーバック）する処理はupdate_mappingメソッドを追加することで行えるようにしました．

### レビューして欲しい所
- fit内部の競合過程，適合過程，協調過程の部分を関数化しても良かったですか？
- 変数名もっといいものがあれば教えて下さい
- 他にもっと良い変更方法やおかしな変更をしている部分がありましたらアドバイス下さい